### PR TITLE
2024.8.5 JSON_Value::parser and SAJ_parser use istream instead of sstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,13 @@ public:
 ```cpp
 class SAJ_Parser
 {
-	static bool SAJ_value(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_object(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_array(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_string(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_number(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_bool(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_null(std::stringstream&, SAJ_Processor&);
+	static bool SAJ_value(std::istream&, SAJ_Processor&);
+	static bool SAJ_object(std::istream&, SAJ_Processor&);
+	static bool SAJ_array(std::istream&, SAJ_Processor&);
+	static bool SAJ_string(std::istream&, SAJ_Processor&);
+	static bool SAJ_number(std::istream&, SAJ_Processor&);
+	static bool SAJ_bool(std::istream&, SAJ_Processor&);
+	static bool SAJ_null(std::istream&, SAJ_Processor&);
 
 	friend void parse_to_SAJ(std::istream&, SAJ_Processor&);
 };

--- a/SAJ_sample.cpp
+++ b/SAJ_sample.cpp
@@ -238,7 +238,6 @@ int main()
 		std::stringstream ss;
 		ss << file.rdbuf();
 		parse_to_SAJ(ss, pro);
-		std::cout << "SAJ success!\n";
 		pro.get_root()->print(std::cout);
 	} else
 		std::cout << "open failed\n";

--- a/doc/设计文档.md
+++ b/doc/设计文档.md
@@ -252,13 +252,13 @@ public:
 ```cpp
 class SAJ_Parser
 {
-	static bool SAJ_value(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_object(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_array(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_string(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_number(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_bool(std::stringstream&, SAJ_Processor&);
-	static bool SAJ_null(std::stringstream&, SAJ_Processor&);
+	static bool SAJ_value(std::istream&, SAJ_Processor&);
+	static bool SAJ_object(std::istream&, SAJ_Processor&);
+	static bool SAJ_array(std::istream&, SAJ_Processor&);
+	static bool SAJ_string(std::istream&, SAJ_Processor&);
+	static bool SAJ_number(std::istream&, SAJ_Processor&);
+	static bool SAJ_bool(std::istream&, SAJ_Processor&);
+	static bool SAJ_null(std::istream&, SAJ_Processor&);
 
 	friend void parse_to_SAJ(std::istream&, SAJ_Processor&);
 };

--- a/src/MyJSON_Value/Global_JSON.cpp
+++ b/src/MyJSON_Value/Global_JSON.cpp
@@ -1,17 +1,16 @@
 #include"Global_JSON.h"
 #include"JSON_Value.h"
-#include <regex>
 
 namespace MyJSON
 {
 	/*----------非成员函数定义----------*/
-	void ignore_blank(std::stringstream& ss)
+	void ignore_blank(std::istream& is)
 	{
-		while (ss.peek() > 0 && ss.peek() <= 32) {
-			if (ss.peek() == '\n') {
+		while (is.peek() > 0 && is.peek() <= 32) {
+			if (is.peek() == '\n') {
 				error_line++;
 			}
-			ss.ignore();
+			is.ignore();
 		}
 	}
 	std::ostream& operator<< (std::ostream& os, std::shared_ptr<JSON_Value>& v)
@@ -65,6 +64,6 @@ namespace MyJSON
 	std::string no_error = "NoError?";
 
 	/*----------全局变量初始化----------*/
-	int tab_deep = 0;
-	int error_line = 1;
+	thread_local int tab_deep = 0;
+	thread_local int error_line = 1;
 }

--- a/src/MyJSON_Value/Global_JSON.h
+++ b/src/MyJSON_Value/Global_JSON.h
@@ -7,6 +7,7 @@
 #include<vector>
 #include<variant>
 #include<memory>
+#include<thread>
 
 namespace MyJSON
 {
@@ -42,11 +43,11 @@ namespace MyJSON
 	extern std::string no_error;
 
 	/*----------非成员函数声明----------*/
-	void ignore_blank(std::stringstream& ss);
+	void ignore_blank(std::istream& is);
 	std::ostream& operator<< (std::ostream& os,
 							  std::shared_ptr<JSON_Value>& v);
 	std::string type_string(JSON_Type& t);
 	/*----------全局变量声明----------*/
-	extern int tab_deep;
-	extern int error_line;
+	thread_local extern int tab_deep;
+	thread_local extern int error_line;
 }

--- a/src/MyJSON_Value/JSON_Array.cpp
+++ b/src/MyJSON_Value/JSON_Array.cpp
@@ -5,7 +5,7 @@ namespace MyJSON
 {
 	/*----------parser----------*/
 	std::shared_ptr<JSON_Value> JSON_Array::parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa)
 	{
 		ignore_blank(ss);
@@ -13,7 +13,8 @@ namespace MyJSON
 			return std::make_shared<JSON_Error>(ss,
 												ss.tellg(),
 												syntax_error_array);
-		}ss.ignore();
+		}
+		ss.ignore();
 
 		std::shared_ptr<JSON_Array> ret = std::make_shared<JSON_Array>();
 		ret->set_father(fa);
@@ -41,9 +42,12 @@ namespace MyJSON
 			} else if (ss.peek() == ']') {
 				ss.ignore();
 				return ret;
-			} else return std::make_shared<JSON_Error>(ss,
-													   ss.tellg(),
-													   syntax_error_array);
+			} else {
+				std::cout << "i haven't got , !\n";
+				return std::make_shared<JSON_Error>(ss,
+													ss.tellg(),
+													syntax_error_array);
+			}
 			/*---next---*/
 		}
 		return std::make_shared<JSON_Error>(ss, ss.tellg(), error_broken_file);

--- a/src/MyJSON_Value/JSON_Array.h
+++ b/src/MyJSON_Value/JSON_Array.h
@@ -9,7 +9,7 @@ namespace MyJSON
 
 	public:
 		std::shared_ptr<JSON_Value> parser(
-			std::stringstream& ss,
+			std::istream& is,
 			std::shared_ptr<JSON_Value> fa) override;
 		std::ostream& print(std::ostream& os) override;
 
@@ -29,6 +29,6 @@ namespace MyJSON
 		}
 
 		JSON_Array():JSON_Value(JARRAY) {}
-		~JSON_Array() {}
+		virtual ~JSON_Array() {}
 	};
 }

--- a/src/MyJSON_Value/JSON_Bool.cpp
+++ b/src/MyJSON_Value/JSON_Bool.cpp
@@ -1,34 +1,51 @@
 #include"JSON_Bool.h"
 #include"JSON_Error.h"
 
-#include<regex>
-
 namespace MyJSON
 {
 	/*----------parser----------*/
 	std::shared_ptr<JSON_Value> JSON_Bool::parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa)
 	{
 		ignore_blank(ss);
-		std::string ms = ss.str().substr(ss.tellg());
-		std::smatch match;
-		std::regex T("^(true)");
-		std::regex F("^(false)");
-		std::shared_ptr<JSON_Bool> ret = std::make_shared<JSON_Bool>();
-		ret->set_father(fa);
-		if (std::regex_search(ms, match, T)) {
-			ret->set_value(true);
-			ss.ignore(4);
-		} else if (std::regex_search(ms, match, F)) {
-			ret->set_value(false);
-			ss.ignore(5);
-		} else {
-			return std::make_shared<JSON_Error>(ss,
-												ss.tellg(),
-												syntax_error_unknown_type);
+		if (ss.peek() == 't') {
+			ss.ignore();
+			if (ss.peek() == 'r') {
+				ss.ignore();
+				if (ss.peek() == 'u') {
+					ss.ignore();
+					if (ss.peek() == 'e') {
+						ss.ignore();
+						std::shared_ptr<JSON_Bool> ret = std::make_shared<JSON_Bool>();
+						ret->set_father(fa);
+						ret->set_value(true);
+						return ret;
+					}
+				}
+			}
+		} else if (ss.peek() == 'f') {
+			ss.ignore();
+			if (ss.peek() == 'a') {
+				ss.ignore();
+				if (ss.peek() == 'l') {
+					ss.ignore();
+					if (ss.peek() == 's') {
+						ss.ignore();
+						if (ss.peek() == 'e') {
+							ss.ignore();
+							std::shared_ptr<JSON_Bool> ret = std::make_shared<JSON_Bool>();
+							ret->set_father(fa);
+							ret->set_value(false);
+							return ret;
+						}
+					}
+				}
+			}
 		}
-		return ret;
+		return std::make_shared<JSON_Error>(ss,
+											ss.tellg(),
+											syntax_error_unknown_type);
 	}
 	/*----------print----------*/
 	std::ostream& JSON_Bool::print(std::ostream& os)

--- a/src/MyJSON_Value/JSON_Bool.h
+++ b/src/MyJSON_Value/JSON_Bool.h
@@ -9,7 +9,7 @@ namespace MyJSON
 
 	public:
 		std::shared_ptr<JSON_Value> parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa) override;
 		std::ostream& print(std::ostream& os) override;
 
@@ -23,6 +23,6 @@ namespace MyJSON
 		}
 
 		JSON_Bool():JSON_Value(JBOOL) {}
-		~JSON_Bool() {}
+		virtual ~JSON_Bool() {}
 	};
 }

--- a/src/MyJSON_Value/JSON_Error.h
+++ b/src/MyJSON_Value/JSON_Error.h
@@ -12,7 +12,7 @@ namespace MyJSON
 
 		std::ostream& print(std::ostream& os) override;
 
-		JSON_Error(std::stringstream& ss, int p = 0, std::string e = no_error):
+		JSON_Error(std::istream& ss, int p = 0, std::string e = no_error):
 			JSON_Value(JERROR),
 			error_type_(e),
 			error_pos_(p)
@@ -20,5 +20,7 @@ namespace MyJSON
 			ss.seekg(error_pos_);
 			getline(ss, error_code_);
 		}
+
+		virtual ~JSON_Error() {}
 	};
 }

--- a/src/MyJSON_Value/JSON_NULL.cpp
+++ b/src/MyJSON_Value/JSON_NULL.cpp
@@ -1,27 +1,44 @@
 #include"JSON_NULL.h"
-#include<regex>
 
 namespace MyJSON
 {
 	/*----------parser----------*/
 	std::shared_ptr<JSON_Value> JSON_NULL::parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa)
 	{
 		ignore_blank(ss);
-		std::string ms = ss.str().substr(ss.tellg());
-		std::smatch match;
-		std::regex N("^(null)");
-		if (std::regex_search(ms, match, N)) {
-			std::shared_ptr<JSON_NULL> ret = std::make_shared<JSON_NULL>();
-			ret->set_father(fa);
-			ss.ignore(4);
-			return ret;
-		} else {
-			return std::make_shared<JSON_Error>(ss,
-												ss.tellg(),
-												syntax_error_unknown_type);
+		if (ss.peek() == 'n') {
+			ss.ignore();
+			if (ss.peek() == 'u') {
+				ss.ignore();
+				if (ss.peek() == 'l') {
+					ss.ignore();
+					if (ss.peek() == 'l') {
+						ss.ignore();
+						std::shared_ptr<JSON_NULL> ret = std::make_shared<JSON_NULL>();
+						ret->set_father(fa);
+						return ret;
+					}
+				}
+			}
 		}
+		return std::make_shared<JSON_Error>(ss,
+											ss.tellg(),
+											syntax_error_unknown_type);
+		// std::string ms = ss.str().substr(ss.tellg());
+		// std::smatch match;
+		// std::regex N("^(null)");
+		// if (std::regex_search(ms, match, N)) {
+		// 	std::shared_ptr<JSON_NULL> ret = std::make_shared<JSON_NULL>();
+		// 	ret->set_father(fa);
+		// 	ss.ignore(4);
+		// 	return ret;
+		// } else {
+		// 	return std::make_shared<JSON_Error>(ss,
+		// 										ss.tellg(),
+		// 										syntax_error_unknown_type);
+		// }
 	}
 	/*----------print----------*/
 	std::ostream& JSON_NULL::print(std::ostream& os)

--- a/src/MyJSON_Value/JSON_NULL.h
+++ b/src/MyJSON_Value/JSON_NULL.h
@@ -8,11 +8,11 @@ namespace MyJSON
 	{
 	public:
 		std::shared_ptr<JSON_Value> parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa) override;
 		std::ostream& print(std::ostream& os) override;
 
 		JSON_NULL():JSON_Value(JNULL) {}
-		~JSON_NULL() {}
+		virtual ~JSON_NULL() {}
 	};
 }

--- a/src/MyJSON_Value/JSON_Number.cpp
+++ b/src/MyJSON_Value/JSON_Number.cpp
@@ -56,15 +56,25 @@ namespace MyJSON
 	}
 	/*----------parser----------*/
 	std::shared_ptr<JSON_Value> JSON_Number::parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa)
 	{
 		ignore_blank(ss);
-		std::string ms = ss.str().substr(ss.tellg());
+		std::string ms = "";
+		while (ss.peek() == '-' || ss.peek() == '+' ||
+			   ss.peek() == '.' || (ss.peek() >= '0' && ss.peek() <= '9') ||
+			   ss.peek() == 'e' || ss.peek() == 'E')
+		{
+			if (ss.peek() == EOF) {
+				break;
+			}
+			ms += ss.peek();
+			ss.ignore();
+		}
 		std::smatch match;
 		std::regex number(
 			"^-?([0]|[1-9][0-9]*)(\\.[0-9]{1,})?([e|E][+|-]?[1-9][0-9]*)?");
-		if (std::regex_search(ms, match, number)) {
+		if (std::regex_match(ms, match, number)) {
 			std::shared_ptr<JSON_Number> ret = std::make_shared<JSON_Number>();
 			ret->set_father(fa);
 			if (!ret->set_value(match.str())) {
@@ -72,7 +82,6 @@ namespace MyJSON
 													ss.tellg(),
 													syntax_error_number);
 			}
-			ss.ignore(match.str().size());
 			return ret;
 		} else {
 			return std::make_shared<JSON_Error>(ss,

--- a/src/MyJSON_Value/JSON_Number.h
+++ b/src/MyJSON_Value/JSON_Number.h
@@ -13,7 +13,7 @@ namespace MyJSON
 		bool out_of_range_ = false;
 	public:
 		std::shared_ptr<JSON_Value> parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa) override;
 		std::ostream& print(std::ostream& os) override;
 
@@ -32,6 +32,6 @@ namespace MyJSON
 		bool set_value(std::string _v);
 
 		JSON_Number():JSON_Value(JNUMBER) {}
-		~JSON_Number() {}
+		virtual ~JSON_Number() {}
 	};
 }

--- a/src/MyJSON_Value/JSON_Object.cpp
+++ b/src/MyJSON_Value/JSON_Object.cpp
@@ -6,7 +6,7 @@ namespace MyJSON
 {
 	/*----------parser----------*/
 	std::shared_ptr<JSON_Value> JSON_Object::parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa)
 	{
 		ignore_blank(ss);

--- a/src/MyJSON_Value/JSON_Object.h
+++ b/src/MyJSON_Value/JSON_Object.h
@@ -15,13 +15,13 @@ namespace MyJSON
 		}
 	public:
 		std::shared_ptr<JSON_Value> parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa) override;
 		std::ostream& print(std::ostream& os) override;
 
 		std::shared_ptr<JSON_Value> operator [] (std::string key)
 		{
-			return child_['"' + key + '"'];
+			return child_[key];
 		}
 		int get_size()
 		{
@@ -30,10 +30,10 @@ namespace MyJSON
 		void insert(std::string key, std::shared_ptr<JSON_Value> value)
 		{
 			value->set_father(shared_from_this());
-			child_.insert({ '"' + key + '"',value });
+			child_.insert({ key,value });
 		}
 
 		JSON_Object():JSON_Value(JOBJECT) {}
-		~JSON_Object() {}
+		virtual ~JSON_Object() {}
 	};
 }

--- a/src/MyJSON_Value/JSON_String.cpp
+++ b/src/MyJSON_Value/JSON_String.cpp
@@ -1,35 +1,44 @@
 #include"JSON_String.h"
 #include"JSON_Error.h"
 
-#include<regex>
-
 namespace MyJSON
 {
 	/*----------parser----------*/
 	std::shared_ptr<JSON_Value> JSON_String::parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa)
 	{
 		ignore_blank(ss);
-		std::string ms = ss.str().substr(ss.tellg());
-		std::smatch match;
-		std::regex pattern("^\"[^\"]*\"");
-		if (std::regex_search(ms, match, pattern)) {
-			std::shared_ptr<JSON_String> ret = std::make_shared<JSON_String>();
-			ret->set_father(fa);
-			ret->parser_set_value(match.str());
-			ss.ignore(match.str().size());
-			return ret;
+		if (ss.peek() == '"') {
+			ss.ignore();
+			std::string str = "";
+			while (ss.peek() != '"' && ss.peek() != EOF)
+			{
+				str += char(ss.peek());
+				ss.ignore();
+			}
+			if (ss.peek() == '"') {
+				ss.ignore();
+				std::shared_ptr<JSON_String> ret =
+					std::make_shared<JSON_String>();
+				ret->set_father(fa);
+				ret->set_value(str);
+				return ret;
+			} else {
+				return std::make_shared<JSON_Error>(ss,
+													ss.tellg(),
+													error_broken_file);
+			}
 		} else {
 			return std::make_shared<JSON_Error>(ss,
 												ss.tellg(),
 												syntax_error_string);
-		} 
+		}
 	}
 	/*----------print----------*/
 	std::ostream& JSON_String::print(std::ostream& os)
 	{
-		os << value_;
+		os << '"' << value_ << '"';
 		return os;
 	}
 }

--- a/src/MyJSON_Value/JSON_String.h
+++ b/src/MyJSON_Value/JSON_String.h
@@ -6,15 +6,9 @@ namespace MyJSON
 	class JSON_String: public JSON_Value
 	{
 		std::string value_ = "";
-		/// @brief 在解析器中调用的设置值（json格式的string带""，为了方便使用，set不用加\"）
-		/// @param string _v 
-		void parser_set_value(std::string _v)
-		{
-			value_ = _v;
-		}
 	public:
 		std::shared_ptr<JSON_Value> parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa) override;
 		std::ostream& print(std::ostream& os) override;
 
@@ -24,10 +18,10 @@ namespace MyJSON
 		}
 		void set_value(std::string _v)
 		{
-			value_ = '"' + _v + '"';
+			value_ = _v;
 		}
 
 		JSON_String():JSON_Value(JSTRING) {}
-		~JSON_String() {}
+		virtual ~JSON_String() {}
 	};
 }

--- a/src/MyJSON_Value/JSON_Value.cpp
+++ b/src/MyJSON_Value/JSON_Value.cpp
@@ -59,19 +59,12 @@ namespace MyJSON
 	}
 
 	/*----------parser----------*/
-	std::shared_ptr<JSON_Value> JSON_Value::parser(
-		std::istream& is,
-		std::shared_ptr<JSON_Value> fa)
-	{
-		std::stringstream ss;
-		ss << is.rdbuf();
-		return parser(ss, fa);
-	}
+
 	/// @brief JSON_value的parser不会变更自身指针，如果在最外层处理的时候记得获取返回值
-	/// @param std::stringstream& ss
+	/// @param std::istream& ss
 	/// @return std::shared_ptr<JSON_Value>
 	std::shared_ptr<JSON_Value> JSON_Value::parser(
-			std::stringstream& ss,
+			std::istream& ss,
 			std::shared_ptr<JSON_Value> fa)
 	{
 		ignore_blank(ss);

--- a/src/MyJSON_Value/JSON_Value.h
+++ b/src/MyJSON_Value/JSON_Value.h
@@ -28,11 +28,8 @@ namespace MyJSON
 			father_ = f;
 		}
 
-		std::shared_ptr<JSON_Value> parser(
-				std::istream& is,
-				std::shared_ptr<JSON_Value> fa = nullptr);
 		virtual std::shared_ptr<JSON_Value> parser(
-				std::stringstream& ss,
+				std::istream& ss,
 				std::shared_ptr<JSON_Value> fa = nullptr);
 
 		virtual std::ostream& print(std::ostream& os);

--- a/src/SAJ/SAJ.cpp
+++ b/src/SAJ/SAJ.cpp
@@ -2,8 +2,8 @@
 
 namespace SAJ
 {
-	int SAJ_Parser::error_line = 1;
-	void SAJ_Parser::ignore_blank(std::stringstream& ss)
+	thread_local int SAJ_Parser::error_line = 1;
+	void SAJ_Parser::ignore_blank(std::istream& ss)
 	{
 		while (ss.peek() > 0 && ss.peek() <= 32) {
 			if (ss.peek() == '\n') {
@@ -14,13 +14,12 @@ namespace SAJ
 	}
 	void parse_to_SAJ(std::istream& is, SAJ_Processor& p)
 	{
-		std::stringstream ss;
-		ss << is.rdbuf();
 		p.parse_start();
-		if (!SAJ_Parser::SAJ_value(ss, p)) {
+		if (!SAJ_Parser::SAJ_value(is, p)) {
 			std::cout << "Error!!!\n";
 			return;
 		}
 		p.parse_end();
+		std::cout << "SAJ success!\n";
 	}
 }

--- a/src/SAJ/SAJ.h
+++ b/src/SAJ/SAJ.h
@@ -2,6 +2,7 @@
 #include<iostream>
 #include<sstream>
 #include<stdint.h>
+#include<thread>
 namespace SAJ
 {
 	//处理器
@@ -28,16 +29,16 @@ namespace SAJ
 	//解析器
 	class SAJ_Parser
 	{
-		static int error_line;
-		static void ignore_blank(std::stringstream& ss);
+		thread_local static int error_line;
+		static void ignore_blank(std::istream& ss);
 		
-		static bool SAJ_value(std::stringstream&, SAJ_Processor&);
-		static bool SAJ_object(std::stringstream&, SAJ_Processor&);
-		static bool SAJ_array(std::stringstream&, SAJ_Processor&);
-		static bool SAJ_string(std::stringstream&, SAJ_Processor&);
-		static bool SAJ_number(std::stringstream&, SAJ_Processor&);
-		static bool SAJ_bool(std::stringstream&, SAJ_Processor&);
-		static bool SAJ_null(std::stringstream&, SAJ_Processor&);
+		static bool SAJ_value(std::istream&, SAJ_Processor&);
+		static bool SAJ_object(std::istream&, SAJ_Processor&);
+		static bool SAJ_array(std::istream&, SAJ_Processor&);
+		static bool SAJ_string(std::istream&, SAJ_Processor&);
+		static bool SAJ_number(std::istream&, SAJ_Processor&);
+		static bool SAJ_bool(std::istream&, SAJ_Processor&);
+		static bool SAJ_null(std::istream&, SAJ_Processor&);
 
 		friend void parse_to_SAJ(std::istream&, SAJ_Processor&);
 	};

--- a/src/SAJ/SAJ_Array.cpp
+++ b/src/SAJ/SAJ_Array.cpp
@@ -2,7 +2,7 @@
 
 namespace SAJ
 {
-	bool SAJ_Parser::SAJ_array(std::stringstream& ss, SAJ_Processor& p)
+	bool SAJ_Parser::SAJ_array(std::istream& ss, SAJ_Processor& p)
 	{
 		p.array_start();
 		if (ss.peek() != '[') {

--- a/src/SAJ/SAJ_Bool.cpp
+++ b/src/SAJ/SAJ_Bool.cpp
@@ -1,28 +1,41 @@
 #include"SAJ.h"
-#include<regex>
 
 namespace SAJ
 {
-	bool SAJ_Parser::SAJ_bool(std::stringstream& ss, SAJ_Processor& p)
+	bool SAJ_Parser::SAJ_bool(std::istream& ss, SAJ_Processor& p)
 	{
 		ignore_blank(ss);
-		std::string ms = ss.str().substr(ss.tellg());
-		std::smatch match;
-		std::regex T("^(true)");
-		std::regex F("^(false)");
-		if (std::regex_search(ms, match, T)) {
-			p.boolean(true);
-			ss.ignore(4);
-			return true;
-		} else if (std::regex_search(ms, match, F)) {
-			p.boolean(false);
-			ss.ignore(5);
-			return true;
-		} else {
-			std::string error_code;
-			getline(ss, error_code);
-			p.error(error_line, "Error: unknown value type");
-			return false;
+		if (ss.peek() == 't') {
+			ss.ignore();
+			if (ss.peek() == 'r') {
+				ss.ignore();
+				if (ss.peek() == 'u') {
+					ss.ignore();
+					if (ss.peek() == 'e') {
+						ss.ignore();
+						p.boolean(true);
+						return true;
+					}
+				}
+			}
+		} else if (ss.peek() == 'f') {
+			ss.ignore();
+			if (ss.peek() == 'a') {
+				ss.ignore();
+				if (ss.peek() == 'l') {
+					ss.ignore();
+					if (ss.peek() == 's') {
+						ss.ignore();
+						if (ss.peek() == 'e') {
+							ss.ignore();
+							p.boolean(false);
+							return true;
+						}
+					}
+				}
+			}
 		}
+		p.error(error_line, "Error: unknown value type");
+		return false;
 	}
 }

--- a/src/SAJ/SAJ_Null.cpp
+++ b/src/SAJ/SAJ_Null.cpp
@@ -1,23 +1,25 @@
 #include"SAJ.h"
-#include<regex>
 
 namespace SAJ
 {
-	bool SAJ_Parser::SAJ_null(std::stringstream& ss, SAJ_Processor& p)
+	bool SAJ_Parser::SAJ_null(std::istream& ss, SAJ_Processor& p)
 	{
 		ignore_blank(ss);
-		std::string ms = ss.str().substr(ss.tellg());
-		std::smatch match;
-		std::regex N("^(null)");
-		if (std::regex_search(ms, match, N)) {
-			p.null();
-			ss.ignore(4);
-			return true;
-		} else {
-			std::string error_code;
-			getline(ss, error_code);
-			p.error(error_line, "Error: unknown value type");
-			return false;
+		if (ss.peek() == 'n') {
+			ss.ignore();
+			if (ss.peek() == 'u') {
+				ss.ignore();
+				if (ss.peek() == 'l') {
+					ss.ignore();
+					if (ss.peek() == 'l') {
+						ss.ignore();
+						p.null();
+						return true;
+					}
+				}
+			}
 		}
+		p.error(error_line, "Error: unknown value type");
+		return false;
 	}
 }

--- a/src/SAJ/SAJ_Number.cpp
+++ b/src/SAJ/SAJ_Number.cpp
@@ -3,17 +3,26 @@
 
 namespace SAJ
 {
-	bool SAJ_Parser::SAJ_number(std::stringstream& ss, SAJ_Processor& p)
+	bool SAJ_Parser::SAJ_number(std::istream& ss, SAJ_Processor& p)
 	{
 		ignore_blank(ss);
-		std::string ms = ss.str().substr(ss.tellg());
+		std::string ms = "";
+		while (ss.peek() == '-' || ss.peek() == '+' ||
+			   ss.peek() == '.' || (ss.peek() >= '0' && ss.peek() <= '9') ||
+			   ss.peek() == 'e' || ss.peek() == 'E')
+		{
+			if (ss.peek() == EOF) {
+				break;
+			}
+			ms += ss.peek();
+			ss.ignore();
+		}
 		std::smatch match;
 		std::regex number(
 			"^-?([0]|[1-9][0-9]*)(\\.[0-9]{1,})?([e|E][+|-]?[1-9][0-9]*)?");
 		if (std::regex_search(ms, match, number)) {
 			bool value_type = false;
 			std::string value = match.str();
-			ss.ignore(match.str().size());
 			// figure int or double
 			for (int i = 0; i < value.size(); i++) {
 				if (value[i] == '.' || value[i] == 'e' || value[i] == 'E') {

--- a/src/SAJ/SAJ_Object.cpp
+++ b/src/SAJ/SAJ_Object.cpp
@@ -1,9 +1,8 @@
 #include"SAJ.h"
-#include<regex>
 
 namespace SAJ
 {
-	bool SAJ_Parser::SAJ_object(std::stringstream& ss, SAJ_Processor& p)
+	bool SAJ_Parser::SAJ_object(std::istream& ss, SAJ_Processor& p)
 	{
 		p.object_start();
 		if (ss.peek() != '{') {
@@ -19,16 +18,23 @@ namespace SAJ
 		while (ss.peek() != EOF) {
 			ignore_blank(ss);
 			/*---key---*/
-			std::string ms = ss.str().substr(ss.tellg());
-			std::smatch match;
-			std::regex pattern("^\"[^\"]*\"");
-			if (std::regex_search(ms, match, pattern)) {
-				p.object_key(match.str());
-				ss.ignore(match.str().size());
+			if (ss.peek() == '"') {
+				ss.ignore();
+				std::string str = "";
+				while (ss.peek() != '"' && ss.peek() != EOF)
+				{
+					str += char(ss.peek());
+					ss.ignore();
+				}
+				if (ss.peek() == '"') {
+					ss.ignore();
+					p.object_key(str);
+				} else {
+					p.error(error_line, "Error: stream ended unexpectedly");
+					return false;
+				}
 			} else {
-				std::string error_code;
-				getline(ss, error_code);
-				p.error(error_line, "Error: object key invalid");
+				p.error(error_line, "Error: object key syntax, Expect: '\"'");
 				return false;
 			}
 			/*---:---*/

--- a/src/SAJ/SAJ_String.cpp
+++ b/src/SAJ/SAJ_String.cpp
@@ -1,23 +1,29 @@
 #include"SAJ.h"
-#include<regex>
 
 namespace SAJ
 {
-	bool SAJ_Parser::SAJ_string(std::stringstream& ss, SAJ_Processor& p)
+	bool SAJ_Parser::SAJ_string(std::istream& ss, SAJ_Processor& p)
 	{
 		ignore_blank(ss);
-		std::string ms = ss.str().substr(ss.tellg());
-		std::smatch match;
-		std::regex pattern("^\"[^\"]*\"");
-		if (std::regex_search(ms, match, pattern)) {
-			p.string(match.str());
-			ss.ignore(match.str().size());
-			return true;
+		if (ss.peek() == '"') {
+			ss.ignore();
+			std::string str = "";
+			while (ss.peek() != '"' && ss.peek() != EOF)
+			{
+				str += char(ss.peek());
+				ss.ignore();
+			}
+			if (ss.peek() == '"') {
+				ss.ignore();
+				p.string(str);
+				return true;
+			} else {
+				p.error(error_line, "Error: stream ended unexpectedly");
+				return false;
+			}
 		} else {
-			std::string error_code;
-			getline(ss, error_code);
-			p.error(error_line, "Error: string invalid");
+			p.error(error_line, "Error: string syntax, Expect: '\"'");
 			return false;
 		}
-}
+	}
 }

--- a/src/SAJ/SAJ_Value.cpp
+++ b/src/SAJ/SAJ_Value.cpp
@@ -2,7 +2,7 @@
 
 namespace SAJ
 {
-	bool SAJ_Parser::SAJ_value(std::stringstream& ss, SAJ_Processor& p)
+	bool SAJ_Parser::SAJ_value(std::istream& ss, SAJ_Processor& p)
 	{
 		ignore_blank(ss);
 		char ch = ss.peek();

--- a/test.cpp
+++ b/test.cpp
@@ -10,8 +10,8 @@ JSON_String str_parser;
 JSON_Number num_parser;
 JSON_Bool boo_parser;
 JSON_NULL nul_parser;
-std::stringstream ss;
-JSON_Error err_parser(ss);
+std::stringstream es;
+JSON_Error err_parser(es);
 std::shared_ptr<JSON_Value> father;
 
 int main(int argc, char **argv)
@@ -47,19 +47,19 @@ TEST(JSON_value, get_xxx)
 }
 TEST(JSON_error, print)
 {
-	std::shared_ptr<JSON_Error> p(new JSON_Error(ss));
+	std::shared_ptr<JSON_Error> p(new JSON_Error(es));
 	p->print(std::cout);
-	p = std::make_shared<JSON_Error>(ss, 0, syntax_error_object);
+	p = std::make_shared<JSON_Error>(es, 0, syntax_error_object);
 	p->print(std::cout);
-	p = std::make_shared<JSON_Error>(ss, 0, syntax_error_array);
+	p = std::make_shared<JSON_Error>(es, 0, syntax_error_array);
 	p->print(std::cout);
-	p = std::make_shared<JSON_Error>(ss, 0, syntax_error_string);
+	p = std::make_shared<JSON_Error>(es, 0, syntax_error_string);
 	p->print(std::cout);
-	p = std::make_shared<JSON_Error>(ss, 0, syntax_error_number);
+	p = std::make_shared<JSON_Error>(es, 0, syntax_error_number);
 	p->print(std::cout);
-	p = std::make_shared<JSON_Error>(ss, 0, syntax_error_unknown_type);
+	p = std::make_shared<JSON_Error>(es, 0, syntax_error_unknown_type);
 	p->print(std::cout);
-	p = std::make_shared<JSON_Error>(ss, 0, error_broken_file);
+	p = std::make_shared<JSON_Error>(es, 0, error_broken_file);
 	p->print(std::cout);
 }
 /*-----类函数-----*/
@@ -72,7 +72,7 @@ TEST(JSON_object, parser)
 	p->print(std::cout);
 	ASSERT_EQ(JOBJECT, p->get_type());
 	EXPECT_EQ(p->get_size(), 4);
-	EXPECT_EQ("\"v1\"", (*p)["key1"]->get_str()->get_value());
+	EXPECT_EQ("v1", (*p)["key1"]->get_str()->get_value());
 	EXPECT_EQ((*(*p)["key5"]->get_arr())[2]->get_num()->get_value_string(), "3");
 
 	EXPECT_EQ(father, p->get_father());
@@ -126,7 +126,7 @@ TEST(JSON_array, parser)
 	EXPECT_EQ(5, (*p)[5]->get_arr()->get_size());
 	EXPECT_EQ(987.65432, std::get<double>((*p)[1]->get_num()->get_value()));
 	EXPECT_EQ(true, (*(*p)[5]->get_arr())[1]->get_boo()->get_value());
-	EXPECT_EQ("\"耶\"", (*(*p)[5]->get_arr())[3]->get_str()->get_value());
+	EXPECT_EQ("耶", (*(*p)[5]->get_arr())[3]->get_str()->get_value());
 	EXPECT_EQ(p, (*p)[3]->get_father());
 	EXPECT_EQ((*p)[5], (*(*p)[5]->get_arr())[4]->get_father());
 }
@@ -153,9 +153,9 @@ TEST(JSON_string, all)
 	std::shared_ptr<JSON_String> p = str_parser.parser(ss, father)->get_str();
 
 	ASSERT_EQ(JSTRING, p->get_type());
-	EXPECT_EQ("\"wi298d9wqh)+*(#^@!~epa{}.jkogq7 qgbc\"", p->get_value());
+	EXPECT_EQ("wi298d9wqh)+*(#^@!~epa{}.jkogq7 qgbc", p->get_value());
 	p->set_value("Hello GTEST  orz");
-	EXPECT_EQ("\"Hello GTEST  orz\"", p->get_value());
+	EXPECT_EQ("Hello GTEST  orz", p->get_value());
 	EXPECT_EQ(p->get_father(), father);
 }
 TEST(JSON_number, all)


### PR DESCRIPTION
Update README and design file  
Use istream instead of streamstring from bottom to top  
Resolved the issue of excessive memory consumption caused by copying the entire stream for regex searching